### PR TITLE
Fix `Comparable#== will no more rescue exceptions of #<=> in the next release.` warning on Ruby 2.2

### DIFF
--- a/lib/xcsim/rbAppBundles.rb
+++ b/lib/xcsim/rbAppBundles.rb
@@ -60,7 +60,7 @@ module XCSim
         nil
       end
     end
-    .select{ |pair| pair != nil }
+    .compact
 
     result = metadataPairs.select{ |pair| pair[:plist][METADATA_ID] == bundleID }
 
@@ -104,7 +104,7 @@ module XCSim
         nil
       end
     end
-    .select { |plist| plist != nil }
+    .compact
 
     bundleInfos = bundlePlists.map do |pair|
       bundleID = pair[:plist][METADATA_ID]

--- a/lib/xcsim/rbDeviceSet.rb
+++ b/lib/xcsim/rbDeviceSet.rb
@@ -23,19 +23,19 @@ module XCSim
     osIDs = defaultDevices
       .keys
       .map{|s| OSID.fromPrefixedString(s) }
-      .select{|id| id != nil}
+      .compact
 
     oses = osIDs.map do |id|
       osDevices = defaultDevices[id.key]
       devices = osDevices
         .keys
         .map{ |s| DeviceID.fromPrefixedString(s, osDevices[s])}
-        .select{ |device| device != nil }
+        .compact
         .select{ |device| File.directory? device.appBundlesPath }
 
         (devices.count > 0) ? OSDevices.new(id, devices) : nil
     end
-    .select{ |os| os != nil }
+    .compact
 
     osHash = {}
     oses.each{ |os| osHash[os.id] = os }


### PR DESCRIPTION
Related issues: https://github.com/wanderwaltz/xcsim/issues/1
