### PR TITLE
Skip simulators with no appDataPath.

### DIFF
--- a/lib/xcsim/rbAppBundles.rb
+++ b/lib/xcsim/rbAppBundles.rb
@@ -44,6 +44,9 @@ module XCSim
   # otherwise.
   def self.findBundleDataPath(deviceID, bundleID)
     path = deviceID.appDataPath
+
+    return nil unless File.directory? path
+
     subdirs = Dir.entries(path).select do |entry|
       File.directory? File.join(path, entry) and !(entry =='.' || entry == '..')
     end
@@ -88,6 +91,9 @@ module XCSim
   # of the bundles.
   def self.parseInstalledBundles(deviceID)
     path = deviceID.appBundlesPath
+
+    return {} unless File.directory? path
+
     subdirs = Dir.entries(path).select do |entry|
       File.directory? File.join(path, entry) and !(entry =='.' || entry == '..')
     end

--- a/lib/xcsim/rbDeviceSet.rb
+++ b/lib/xcsim/rbDeviceSet.rb
@@ -32,6 +32,7 @@ module XCSim
         .map{ |s| DeviceID.fromPrefixedString(s, osDevices[s])}
         .compact
         .select{ |device| File.directory? device.appBundlesPath }
+        .select{ |device| File.directory? device.appDataPath }
 
         (devices.count > 0) ? OSDevices.new(id, devices) : nil
     end


### PR DESCRIPTION
Related issues: https://github.com/wanderwaltz/xcsim/issues/2
